### PR TITLE
Proper pip requirements file added

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-pip install path.py
-pip install numpy
-pip install Pillow
-pip install argparse
+path.py>=12.5.0
+numpy>=1.19.2
+Pillow>=7.2.0
+argparse>=1.4.0


### PR DESCRIPTION
To run 
```
pip install -r requirements.txt
```
proper package name with version required, the above command just look the package name and the version what user want to install
``` pip install packageName ```  in requirement will not work
By the way great project 👍🏻 